### PR TITLE
Verify $url['scheme'] is available

### DIFF
--- a/src/Aura/Http/Adapter/Stream.php
+++ b/src/Aura/Http/Adapter/Stream.php
@@ -314,6 +314,11 @@ class Stream implements AdapterInterface
 
         // what scheme are we using?
         $url = parse_url($this->request->url);
+
+        if (empty($url['scheme'])) {
+            $url['scheme'] = 'http';
+        }
+
         if ($url['scheme'] == 'https') {
             // secure scheme
             $this->setContextOptionsSecure();


### PR DESCRIPTION
Added in a check that will validate there is a scheme on the parsed url and if not add a default http.

This solves the bug reported in issue #32 
