### PR TITLE
Added HTTP 451 status code

### DIFF
--- a/src/Aura/Http/Message/Response.php
+++ b/src/Aura/Http/Message/Response.php
@@ -67,6 +67,7 @@ class Response extends Message
         '415' => 'Unsupported Media Type',
         '416' => 'Requested Range Not Satisfiable',
         '417' => 'Expectation Failed',
+        '451' => 'Unavailable For Legal Reasons',
 
         '500' => 'Internal Server Error',
         '501' => 'Not Implemented',


### PR DESCRIPTION
https://datatracker.ietf.org/doc/draft-ietf-httpbis-legally-restricted-status/?include_text=1

The HTTP 451 status code was approved by the ISG a few days ago on the 18th December '15.
